### PR TITLE
Colors Unit Tests

### DIFF
--- a/.idea/runConfigurations/Jasmine_Tests.xml
+++ b/.idea/runConfigurations/Jasmine_Tests.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Jasmine Tests" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="test" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,7 +29,13 @@ module.exports = function (config) {
 		customLaunchers: {
 			ChromeHeadlessCI: {
 				base: 'ChromeHeadless',
-				flags: ['--no-sandbox'],
+				flags: [
+					'--no-sandbox',
+					'--no-first-run',
+					'--disable-gpu',
+					'--disable-translate',
+					'--disable-extensions'
+				],
 			},
 		},
 		singleRun: false,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"watch": "ng build --watch",
 		"serve": "ng serve",
 		"test": "ng test",
+		"test-ci": "ng test --configuration=ci",
 		"test-code-coverage": "ng test --code-coverage",
 		"lint": "ng lint",
 		"e2e": "ng e2e"

--- a/src/app/shared/colors/models/color-palettes/color-palette.model.spec.ts
+++ b/src/app/shared/colors/models/color-palettes/color-palette.model.spec.ts
@@ -1,0 +1,96 @@
+import { Color } from '../color.model';
+import { BluePalette } from './color-palettes.constant';
+
+describe('Color Palette', () => {
+
+	describe('Internal Color Objects', () => {
+		it('should contain correct lightestColor', () => {
+			const { lightestColor } = BluePalette;
+			expect(lightestColor).toBeInstanceOf(Color);
+			expect(lightestColor.toString()).toBe('rgb(81, 212, 255)');
+		});
+
+		it('should contain correct lighterColor', () => {
+			const { lighterColor } = BluePalette;
+			expect(lighterColor).toBeInstanceOf(Color);
+			expect(lighterColor.toString()).toBe('rgb(26, 180, 245)');
+		});
+
+		it('should contain correct lightColor', () => {
+			const { lightColor } = BluePalette;
+			expect(lightColor).toBeInstanceOf(Color);
+			expect(lightColor.toString()).toBe('rgb(0, 179, 238)');
+		});
+
+		it('should contain correct defaultColor', () => {
+			const { defaultColor } = BluePalette;
+			expect(defaultColor).toBeInstanceOf(Color);
+			expect(defaultColor.toString()).toBe('rgb(3, 157, 221)');
+		});
+
+		it('should contain correct darkColor', () => {
+			const { darkColor } = BluePalette;
+			expect(darkColor).toBeInstanceOf(Color);
+			expect(darkColor.toString()).toBe('rgb(4, 135, 204)');
+		});
+
+		it('should contain correct darkerColor', () => {
+			const { darkerColor } = BluePalette;
+			expect(darkerColor).toBeInstanceOf(Color);
+			expect(darkerColor.toString()).toBe('rgb(4, 126, 197)');
+		});
+
+		it('should contain correct darkestColor', () => {
+			const { darkestColor } = BluePalette;
+			expect(darkestColor).toBeInstanceOf(Color);
+			expect(darkestColor.toString()).toBe('rgb(3, 110, 166)');
+		});
+	});
+
+	describe('Base Color Palette Values', () => {
+		it('should contain correct colorLightest', () => {
+			const { colorLightest } = BluePalette;
+			expect(colorLightest).toBe('rgb(81, 212, 255)');
+		});
+
+		it('should contain correct colorLighter', () => {
+			const { colorLighter } = BluePalette;
+			expect(colorLighter).toBe('rgb(26, 180, 245)');
+		});
+
+		it('should contain correct colorLight', () => {
+			const { colorLight } = BluePalette;
+			expect(colorLight).toBe('rgb(0, 179, 238)');
+		});
+
+		it('should contain correct colorDefault', () => {
+			const { colorDefault } = BluePalette;
+			expect(colorDefault).toBe('rgb(3, 157, 221)');
+		});
+
+		it('should contain correct colorDark', () => {
+			const { colorDark } = BluePalette;
+			expect(colorDark).toBe('rgb(4, 135, 204)');
+		});
+
+		it('should contain correct colorDarker', () => {
+			const { colorDarker } = BluePalette;
+			expect(colorDarker).toBe('rgb(4, 126, 197)');
+		});
+
+		it('should contain correct colorDarkest', () => {
+			const { colorDarkest } = BluePalette;
+			expect(colorDarkest).toBe('rgb(3, 110, 166)');
+		});
+
+		it('should contain correct colorSelected', () => {
+			const { colorSelected } = BluePalette;
+			expect(colorSelected).toBe('rgba(3, 157, 221, 0.25)');
+		});
+
+		it('should contain correct colorSelectedOpaque', () => {
+			const { colorSelectedOpaque } = BluePalette;
+			expect(colorSelectedOpaque).toBe('rgb(192, 231, 247)');
+		});
+	});
+});

--- a/src/app/shared/colors/models/color-palettes/color-palette.model.spec.ts
+++ b/src/app/shared/colors/models/color-palettes/color-palette.model.spec.ts
@@ -93,4 +93,53 @@ describe('Color Palette', () => {
 			expect(colorSelectedOpaque).toBe('rgb(192, 231, 247)');
 		});
 	});
+
+	describe('ColorPalette.getInverse()', () => {
+		const bluePaletteInverse = BluePalette.getInverse();
+
+		it('should contain correct colorLightest', () => {
+			const { colorLightest } = bluePaletteInverse;
+			expect(colorLightest).toBe('rgb(3, 110, 166)');
+		});
+
+		it('should contain correct colorLighter', () => {
+			const { colorLighter } = bluePaletteInverse;
+			expect(colorLighter).toBe('rgb(4, 126, 197)');
+		});
+
+		it('should contain correct colorLight', () => {
+			const { colorLight } = bluePaletteInverse;
+			expect(colorLight).toBe('rgb(4, 135, 204)');
+		});
+
+		it('should contain correct colorDefault', () => {
+			const { colorDefault } = bluePaletteInverse;
+			expect(colorDefault).toBe('rgb(3, 157, 221)');
+		});
+
+		it('should contain correct colorDark', () => {
+			const { colorDark } = bluePaletteInverse;
+			expect(colorDark).toBe('rgb(0, 179, 238)');
+		});
+
+		it('should contain correct colorDarker', () => {
+			const { colorDarker } = bluePaletteInverse;
+			expect(colorDarker).toBe('rgb(26, 180, 245)');
+		});
+
+		it('should contain correct colorDarkest', () => {
+			const { colorDarkest } = bluePaletteInverse;
+			expect(colorDarkest).toBe('rgb(81, 212, 255)');
+		});
+
+		it('should contain correct colorSelected', () => {
+			const { colorSelected } = bluePaletteInverse;
+			expect(colorSelected).toBe('rgba(3, 157, 221, 0.25)');
+		});
+
+		it('should contain correct colorSelectedOpaque', () => {
+			const { colorSelectedOpaque } = bluePaletteInverse;
+			expect(colorSelectedOpaque).toBe('rgb(26, 64, 80)');
+		});
+	});
 });

--- a/src/app/shared/colors/models/color-palettes/color-palette.model.ts
+++ b/src/app/shared/colors/models/color-palettes/color-palette.model.ts
@@ -4,13 +4,13 @@ import { LightTheme, DarkTheme } from '../color-themes/color-themes.constant';
 
 export class ColorPalette extends BaseColorPalette {
 	public constructor(
-		private readonly lightestColor: Color,
-		private readonly lighterColor: Color,
-		private readonly lightColor: Color,
-		private readonly defaultColor: Color,
-		private readonly darkColor: Color,
-		private readonly darkerColor: Color,
-		private readonly darkestColor: Color,
+		public readonly lightestColor: Color,
+		public readonly lighterColor: Color,
+		public readonly lightColor: Color,
+		public readonly defaultColor: Color,
+		public readonly darkColor: Color,
+		public readonly darkerColor: Color,
+		public readonly darkestColor: Color,
 
 		public readonly paletteName: string,
 		public readonly displayName: string,

--- a/src/app/shared/colors/models/color-themes/color-theme.model.spec.ts
+++ b/src/app/shared/colors/models/color-themes/color-theme.model.spec.ts
@@ -1,0 +1,58 @@
+import { LightTheme } from './color-themes.constant';
+import { Color } from '../color.model';
+
+describe('Color Theme', () => {
+
+	describe('Internal Color Objects', () => {
+		it('should contain correct backgroundColor', () => {
+			const { backgroundColor } = LightTheme;
+			expect(backgroundColor).toBeInstanceOf(Color);
+			expect(backgroundColor.toString()).toBe('rgb(255, 255, 255)');
+		});
+
+		it('should contain correct accentColor', () => {
+			const { accentColor } = LightTheme;
+			expect(accentColor).toBeInstanceOf(Color);
+			expect(accentColor.toString()).toBe('rgb(245, 245, 245)');
+		});
+
+		it('should contain correct disabledColor', () => {
+			const { disabledColor } = LightTheme;
+			expect(disabledColor).toBeInstanceOf(Color);
+			expect(disabledColor.toString()).toBe('rgb(211, 211, 211)');
+		});
+
+		it('should contain correct contrastColor', () => {
+			const { contrastColor } = LightTheme;
+			expect(contrastColor).toBeInstanceOf(Color);
+			expect(contrastColor.toString()).toBe('rgba(0, 0, 0, 0.87)');
+		});
+	});
+
+	describe('Base Color Theme Values', () => {
+		it('should contain correct colorBackground', () => {
+			const { colorBackground } = LightTheme;
+			expect(colorBackground).toBe('rgb(255, 255, 255)');
+		});
+
+		it('should contain correct colorAccent', () => {
+			const { colorAccent } = LightTheme;
+			expect(colorAccent).toBe('rgb(245, 245, 245)');
+		});
+
+		it('should contain correct colorDisabled', () => {
+			const { colorDisabled } = LightTheme;
+			expect(colorDisabled).toBe('rgb(211, 211, 211)');
+		});
+
+		it('should contain correct colorContrast', () => {
+			const { colorContrast } = LightTheme;
+			expect(colorContrast).toBe('rgba(0, 0, 0, 0.87)');
+		});
+
+		it('should contain correct colorHover', () => {
+			const { colorHover } = LightTheme;
+			expect(colorHover).toBe('rgba(0, 0, 0, 0.15)');
+		});
+	});
+});

--- a/src/app/shared/colors/services/colors.service.spec.ts
+++ b/src/app/shared/colors/services/colors.service.spec.ts
@@ -1,16 +1,108 @@
-import { TestBed } from '@angular/core/testing';
-
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ColorsService } from './colors.service';
+import { DarkTheme, LightTheme } from '../models/color-themes/color-themes.constant';
+import { BluePalette, GreenPalette } from '../models/color-palettes/color-palettes.constant';
+import { BaseColorTheme } from '../models/color-themes/base-color-theme.model';
+import { BaseColorPalette } from '../models/color-palettes/base-color-palette.model';
+import { ColorTheme } from '../models/color-themes/color-theme.model';
+import { ColorPalette } from '../models/color-palettes/color-palette.model';
 
 describe('ColorsService', () => {
-	let service: ColorsService;
+	let colorsService: ColorsService;
+
+	const body = document.body;
+	const style = document.documentElement.style;
+
+	let theme: ColorTheme;
+	let palette: ColorPalette;
+
+	const BUFFER_TIME = 50;
+
+	function setDarkTheme(): void {
+		fakeAsync(() => {
+			colorsService.toggleTheme(DarkTheme);
+			theme = DarkTheme;
+			tick(BUFFER_TIME);
+		});
+	}
+
+	function setGreenPalette(): void {
+		fakeAsync(() => {
+			colorsService.togglePalette(GreenPalette);
+			palette = GreenPalette;
+			tick(BUFFER_TIME);
+		});
+	}
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({});
-		service = TestBed.inject(ColorsService);
+		colorsService = TestBed.inject(ColorsService);
+
+		theme = LightTheme;
+		palette = BluePalette;
 	});
 
-	it('should be created', () => {
-		expect(service).toBeTruthy();
+	afterEach(() => {
+		colorsService.toggleTheme(LightTheme);
+		colorsService.togglePalette(BluePalette);
+	});
+
+	describe('LocalStorage', () => {
+		it('should have set "theme": "light-theme" in localstorage', () => {
+			expect(localStorage.getItem('theme')).toBe(theme.themeName);
+		});
+
+		it('should have set "palette": "blue-palette" in localstorage', () => {
+			expect(localStorage.getItem('palette')).toBe(palette.paletteName);
+		});
+
+		it('should update "theme": "dark-theme" in localstorage', () => {
+			setDarkTheme();
+			expect(localStorage.getItem('theme')).toBe(theme.themeName);
+		});
+
+		it('should update "palette": "green-palette" in localstorage', () => {
+			setGreenPalette();
+			expect(localStorage.getItem('palette')).toBe(palette.paletteName);
+		});
+	});
+
+	describe('Body Theme Class', () => {
+		it('should have set "light-theme" class on body', () => {
+			expect(body.classList.contains(theme.themeName)).toBeTruthy();
+		});
+
+		it('should update "dark-theme" class on body', () => {
+			setDarkTheme();
+			expect(body.classList.contains(theme.themeName)).toBeTruthy();
+		});
+	});
+
+	describe('CSS Variables', () => {
+		it('should have set theme css values on element', () => {
+			Object.entries(BaseColorTheme.CssThemeVariables).forEach(([key, cssVariable]) => {
+				expect(style.getPropertyValue(cssVariable)).toBe(theme[key]);
+			});
+		});
+
+		it('should have set palette css values on element', () => {
+			Object.entries(BaseColorPalette.CssPaletteVariables).forEach(([key, cssVariable]) => {
+				expect(style.getPropertyValue(cssVariable)).toBe(palette[key]);
+			});
+		});
+
+		it('should update theme css values on toggleTheme', () => {
+			setDarkTheme();
+			Object.entries(BaseColorTheme.CssThemeVariables).forEach(([key, cssVariable]) => {
+				expect(style.getPropertyValue(cssVariable)).toBe(theme[key]);
+			});
+		});
+
+		it('should update palette css values on togglePalette', () => {
+			setGreenPalette();
+			Object.entries(BaseColorPalette.CssPaletteVariables).forEach(([key, cssVariable]) => {
+				expect(style.getPropertyValue(cssVariable)).toBe(palette[key]);
+			});
+		});
 	});
 });

--- a/src/app/shared/colors/services/colors.service.spec.ts
+++ b/src/app/shared/colors/services/colors.service.spec.ts
@@ -18,20 +18,24 @@ describe('ColorsService', () => {
 
 	const BUFFER_TIME = 50;
 
+	/** must be encapsulated by a fakeAsync */
 	function setDarkTheme(): void {
-		fakeAsync(() => {
-			colorsService.toggleTheme(DarkTheme);
-			theme = DarkTheme;
-			tick(BUFFER_TIME);
-		});
+		colorsService.toggleTheme(DarkTheme);
+
+		theme = DarkTheme;
+		palette = palette.getInverse();
+
+		tick(BUFFER_TIME);
 	}
 
+	/** must be encapsulated by a fakeAsync */
 	function setGreenPalette(): void {
-		fakeAsync(() => {
-			colorsService.togglePalette(GreenPalette);
-			palette = GreenPalette;
-			tick(BUFFER_TIME);
-		});
+		colorsService.togglePalette(GreenPalette);
+
+		palette = (theme.themeName === LightTheme.themeName)
+			? GreenPalette : GreenPalette.getInverse();
+
+		tick(BUFFER_TIME);
 	}
 
 	beforeEach(() => {
@@ -56,15 +60,15 @@ describe('ColorsService', () => {
 			expect(localStorage.getItem('palette')).toBe(palette.paletteName);
 		});
 
-		it('should update "theme": "dark-theme" in localstorage', () => {
+		it('should update "theme": "dark-theme" in localstorage', fakeAsync(() => {
 			setDarkTheme();
 			expect(localStorage.getItem('theme')).toBe(theme.themeName);
-		});
+		}));
 
-		it('should update "palette": "green-palette" in localstorage', () => {
+		it('should update "palette": "green-palette" in localstorage', fakeAsync(() => {
 			setGreenPalette();
 			expect(localStorage.getItem('palette')).toBe(palette.paletteName);
-		});
+		}));
 	});
 
 	describe('Body Theme Class', () => {
@@ -72,10 +76,10 @@ describe('ColorsService', () => {
 			expect(body.classList.contains(theme.themeName)).toBeTruthy();
 		});
 
-		it('should update "dark-theme" class on body', () => {
+		it('should update "dark-theme" class on body', fakeAsync(() => {
 			setDarkTheme();
 			expect(body.classList.contains(theme.themeName)).toBeTruthy();
-		});
+		}));
 	});
 
 	describe('CSS Variables', () => {
@@ -91,18 +95,25 @@ describe('ColorsService', () => {
 			});
 		});
 
-		it('should update theme css values on toggleTheme', () => {
+		it('should update theme css values on toggleTheme', fakeAsync(() => {
 			setDarkTheme();
 			Object.entries(BaseColorTheme.CssThemeVariables).forEach(([key, cssVariable]) => {
 				expect(style.getPropertyValue(cssVariable)).toBe(theme[key]);
 			});
-		});
+		}));
 
-		it('should update palette css values on togglePalette', () => {
+		it('should update palette css values on togglePalette', fakeAsync(() => {
 			setGreenPalette();
 			Object.entries(BaseColorPalette.CssPaletteVariables).forEach(([key, cssVariable]) => {
 				expect(style.getPropertyValue(cssVariable)).toBe(palette[key]);
 			});
-		});
+		}));
+
+		it('should update inverse palette css values on toggleTheme', fakeAsync(() => {
+			setDarkTheme();
+			Object.entries(BaseColorPalette.CssPaletteVariables).forEach(([key, cssVariable]) => {
+				expect(style.getPropertyValue(cssVariable)).toBe(palette[key]);
+			});
+		}));
 	});
 });

--- a/src/styles/colors/colors.scss
+++ b/src/styles/colors/colors.scss
@@ -1,4 +1,4 @@
-:root {
+.demo-colors {
 	// Light Theme Default Values
 	--theme-color-background: white;
 	--theme-color-accent: whitesmoke;


### PR DESCRIPTION
Stores theme and palette on the ColorsService, instead of fetching them by name on body.

Adds unit tests for `ColorTheme`, `ColorPalette`, and `ColorsService`,

Adds an intellij config for jasmine tests