### PR TITLE
Actions/Checkout uses GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,7 +9,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:  
-                    token: ${{ secrets.ACTIONS_TOKEN }}
+                    token: ${{ secrets.GITHUB_TOKEN }}
             -   uses: ahmadnassri/action-dependabot-auto-merge@master
                 with:
                     target: minor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2
+                with:
+                    token: ${{ secrets.GITHUB_TOKEN }}
             -   name: Cache Node Modules
                 uses: actions/cache@v2
                 env:
@@ -35,8 +37,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2
-                with:  
-                    token: ${{ secrets.ACTIONS_TOKEN }}
+                with:
+                    token: ${{ secrets.GITHUB_TOKEN }}
             -   name: Automated Version Bump
                 uses: phips28/gh-action-bump-version@master
                 env:


### PR DESCRIPTION
In theory, this should stop Actions from performing recursive CI after `Automated Version Bump`