### PR TITLE
Testing ACTIONS_TOKEN → REPOSITORY_ACTIONS_TOKEN

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,10 +8,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2
-                with:  
-                    token: ${{ secrets.GITHUB_TOKEN }}
+                with:
+                    token: ${{ secrets.REPOSITORY_ACTIONS_TOKEN }}
             -   uses: ahmadnassri/action-dependabot-auto-merge@master
                 with:
                     target: minor
                     command: squash and merge
-                    github-token: ${{ secrets.ACTIONS_TOKEN }}
+                    github-token: ${{ secrets.REPOSITORY_ACTIONS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,11 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    token: ${{ secrets.GITHUB_TOKEN }}
+                    token: ${{ secrets.REPOSITORY_ACTIONS_TOKEN }}
             -   name: Automated Version Bump
                 uses: phips28/gh-action-bump-version@master
                 env:
-                    GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}                    
+                    GITHUB_TOKEN: ${{ secrets.REPOSITORY_ACTIONS_TOKEN }}
             -   name: Cache Node Modules
                 uses: actions/cache@v2
                 env:


### PR DESCRIPTION
#30 Did manage to prevent the recursion, in the sense that the `Automated Version Bump` failed to push.

Now testing a new secret, `REPOSITORY_ACTIONS_TOKEN`, that doesn't have the `workflow` scope. My instinct is that this will reintroduce the duplicate stage of `Automated Version Bump` and regress to cause double deploys again.