### PR TITLE
fixes auto-merge after dependabot started acting like a fork

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,7 +8,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    token: ${{ secrets.REPOSITORY_ACTIONS_TOKEN }}
+                    token: ${{ secrets.GITHUB_TOKEN }}
             -   uses: ahmadnassri/action-dependabot-auto-merge@master
                 with:
                     target: minor

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,6 @@
 name: Auto Merge Dependabot
 on:
-    pull_request:
+    pull_request_target:
 jobs:
     auto-merge:
         name: Auto Merge Dependabot
@@ -8,7 +8,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    token: ${{ secrets.GITHUB_TOKEN }}
+                    token: ${{ secrets.REPOSITORY_ACTIONS_TOKEN }}
             -   uses: ahmadnassri/action-dependabot-auto-merge@master
                 with:
                     target: minor


### PR DESCRIPTION
Because `Dependabot` now acts like a fork, if doesn't have traditional access to secrets.

[GitHub's blog post about changing Dependabot to act like a fork](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)

[Using `pull_request_target`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target)

[The issue in the source repo](https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60)

[An article discussing a solution](https://www.linkedin.com/pulse/how-keep-your-npm-dependencies-up-to-date-without-wasting-gorej/)