### PR TITLE
refactored Observed `{ type: subject }` instances

### DIFF
--- a/src/app/features/refresh/refresh-button/refresh-button.component.ts
+++ b/src/app/features/refresh/refresh-button/refresh-button.component.ts
@@ -23,7 +23,7 @@ export class RefreshButtonComponent<T> implements OnInit {
 	/* time spent in DONE state (milliseconds) */
 	@Input() public debounceTime = 10_000;
 
-	@Observed({ type: 'subject' }) private doRefresh: void;
+	@Observed('subject') private doRefresh: void;
 	@Observed() public refreshState = RefreshState.IDLE;
 
 	public readonly doRefresh$: Observable<void>;

--- a/src/app/features/snek/services/core/snek-resolution.service.ts
+++ b/src/app/features/snek/services/core/snek-resolution.service.ts
@@ -14,7 +14,7 @@ export class SnekResolutionService implements OnDestroy {
 
 	@Observed() public snekWidth: number;
 	@Observed() public snekHeight: number;
-	@Observed({ type: 'subject' }) private onResolutionChange: [ number, number ] = null;
+	@Observed('subject') private onResolutionChange: [ number, number ] = null;
 
 	public readonly snekWidth$: Observable<number>;
 	public readonly snekHeight$: Observable<number>;

--- a/src/app/features/snek/services/core/snek-state.service.ts
+++ b/src/app/features/snek/services/core/snek-state.service.ts
@@ -30,7 +30,7 @@ export class SnekStateService implements OnDestroy {
 	@Observed() public gameState: SnekGameState = null;
 	public readonly gameState$: Observable<SnekGameState>;
 
-	@Observed({ type: 'subject' }) private gameOver: string = null;
+	@Observed('subject') private gameOver: string = null;
 	public readonly gameOver$: Observable<string>;
 
 	public constructor(


### PR DESCRIPTION
The `@Observed` decorator now allows subjects to be defined as follows:

```ts
@Observed('subject') myNumber: number;
```

So, I refactored all instances of `{ type: 'subject' }` → `'subject'`.