### PR TITLE
fixed canvas pixel densities

### DIFF
--- a/src/app/features/background/services/canvas.service.ts
+++ b/src/app/features/background/services/canvas.service.ts
@@ -22,7 +22,6 @@ export abstract class CanvasService implements OnDestroy {
 
 	protected constructor() {
 		effect(() => this.setCanvasResolution());
-		effect(() => this.setContextScale());
 	}
 
 	public ngOnDestroy(): void {
@@ -37,18 +36,10 @@ export abstract class CanvasService implements OnDestroy {
 		const canvas = this.canvas();
 
 		if (canvas !== null) {
-			canvas.style.height = `${ this.rawCanvasHeight() }px`;
 			canvas.style.width = `${ this.rawCanvasWidth() }px`;
+			canvas.style.height = `${ this.rawCanvasHeight() }px`;
 			canvas.width = this.canvasWidth();
 			canvas.height = this.canvasHeight();
-		}
-	}
-
-	private setContextScale(): void {
-		const context = this.context();
-
-		if (context !== null) {
-			context.scale(this.pixelDensity(), this.pixelDensity());
 		}
 	}
 }

--- a/src/app/features/snek/models/direction/snek-direction.enum.ts
+++ b/src/app/features/snek/models/direction/snek-direction.enum.ts
@@ -72,17 +72,17 @@ export abstract class SnekDirectionUtil {
 		}
 	}
 
-	public static getIconTranslation(direction: SnekDirection | null): [ number, number ] {
+	public static getIconTranslation(direction: SnekDirection | null, scalar: number): [ number, number ] {
 		switch (direction) {
 			default:
 			case SnekDirection.RIGHT:
 				return [ 0, 0 ];
 			case SnekDirection.DOWN:
-				return [ 20, 0 ];
+				return [ scalar, 0 ];
 			case SnekDirection.LEFT:
-				return [ 20, 20 ];
+				return [ scalar, scalar ];
 			case SnekDirection.UP:
-				return [ 0, 20 ];
+				return [ 0, scalar ];
 		}
 	}
 }

--- a/src/app/features/snek/models/grid/snek-grid-node.model.ts
+++ b/src/app/features/snek/models/grid/snek-grid-node.model.ts
@@ -72,10 +72,10 @@ export class SnekGridNode {
 		return SnekDirectionUtil.getIconRotation(this.#snekNode?.direction ?? null);
 	}
 
-	public getIconTranslation(): [ number, number ] {
-		const [ widthOffset, heightOffset ] = SnekDirectionUtil.getIconTranslation(this.#snekNode?.direction ?? null);
+	public getIconTranslation(scalar: number): [ number, number ] {
+		const [ widthOffset, heightOffset ] = SnekDirectionUtil.getIconTranslation(this.#snekNode?.direction ?? null, scalar);
 
-		return [ this.width * 20 + widthOffset, this.height * 20 + heightOffset ];
+		return [ this.width * scalar + widthOffset, this.height * scalar + heightOffset ];
 	}
 
 	public get type(): SnekGridNodeType {

--- a/src/app/features/snek/services/core/snek-canvas.service.ts
+++ b/src/app/features/snek/services/core/snek-canvas.service.ts
@@ -16,6 +16,7 @@ export class SnekCanvasService extends CanvasService {
 	private readonly snekStateService = inject(SnekStateService);
 	private readonly svgIconService = inject(SvgIconService);
 
+	private readonly scalar = computed(() => this.pixelDensity() * 20);
 	protected readonly rawCanvasWidth = computed(() => this.snekResolutionService.snekWidth() * 20);
 	protected readonly rawCanvasHeight = computed(() => this.snekResolutionService.snekHeight() * 20);
 
@@ -72,12 +73,13 @@ export class SnekCanvasService extends CanvasService {
 
 	private drawGridNode(context: CanvasRenderingContext2D, width: number, height: number) {
 		const colorTheme = untracked(this.colorsService.theme);
+		const scalar = untracked(this.scalar);
 
 		context.fillStyle = ((width + height) % 2 === 1)
 			? colorTheme.colorDefaultBackground
 			: colorTheme.colorAccentBackground;
 
-		context.fillRect(width * 20, height * 20, 20, 20);
+		context.fillRect(width * scalar, height * scalar, scalar, scalar);
 	}
 
 	private drawSnekNode(context: CanvasRenderingContext2D, snekGridNode: SnekGridNode, gameCounter: number): void {
@@ -92,10 +94,11 @@ export class SnekCanvasService extends CanvasService {
 		const pathString = svgPath.attributes.getNamedItem('d')?.nodeValue ?? null;
 		if (pathString === null) return;
 
+		const scalar = untracked(this.scalar);
 		const domMatrix = svgPath.ownerSVGElement?.createSVGMatrix()
-			.translate(...snekGridNode.getIconTranslation())
+			.translate(...snekGridNode.getIconTranslation(scalar))
 			.rotate(snekGridNode.getIconRotation())
-			.scale(20 / 100);
+			.scale(scalar / 100);
 
 		const path = new Path2D();
 		path.addPath(new Path2D(pathString), domMatrix);


### PR DESCRIPTION
Unfortunately, the proper solution is to just _not_ scale the canvas.

But that does mean that implementing members may need to be aware of the pixel density when transposing drawn items.