### PR TITLE
dyslexic inner html

### DIFF
--- a/src/app/features/about/components/about-card/about-card.component.html
+++ b/src/app/features/about/components/about-card/about-card.component.html
@@ -34,7 +34,7 @@
 	@if (data().paragraphs) {
 		<mat-card-content class="paragraphs">
 			@for (paragraph of data().paragraphs; track $index) {
-				<p [innerHtml]="paragraph"></p>
+				<p><dyslexic-text [text]="paragraph"/></p>
 			}
 		</mat-card-content>
 	}

--- a/src/app/features/background/components/background-dialog/background-dialog.component.html
+++ b/src/app/features/background/components/background-dialog/background-dialog.component.html
@@ -1,7 +1,12 @@
 <base-dialog [configuration]="dialogConfiguration()">
 	<main>
-		<p>The background moves. Did you notice? You sly you.</p>
-		<p>But we can fix that. Go ahead. I won't tell.</p>
+		<p><dyslexic-text text="
+			Now let me get this straight. You're telling me you see the background moving too?
+			I thought that was a figment of <i>my</i> imagination.
+		"/></p>
+		<p><dyslexic-text text="
+			Well. We can fix that. Go ahead. I won't tell.
+		"/></p>
 
 		<mat-checkbox class="mat-menu-item" color="primary"
 					  [formControl]="enabledControl"
@@ -9,7 +14,11 @@
 			{{ enabled() ? 'Background Moves' : 'Not anymore' }}
 		</mat-checkbox>
 
-		<p>{{ enabled() ? 'Oh you want some more? Less?' : 'Well never mind then.' }}</p>
+		@if (enabled()) {
+			<p><dyslexic-text text="Oh you want some more? Less?"/></p>
+		} @else {
+			<p><dyslexic-text text="Well never mind then."/></p>
+		}
 
 		<mat-slider showTickMarks color="primary" min="0" max="20" step="1"
 					[disabled]="!enabled()">

--- a/src/app/features/background/components/background-dialog/background-dialog.component.ts
+++ b/src/app/features/background/components/background-dialog/background-dialog.component.ts
@@ -9,6 +9,7 @@ import { BaseDialogComponent } from 'src/app/features/dialogs/components/base-di
 import { DialogComponent } from 'src/app/features/dialogs/components/dialog.component';
 import { DialogBuilder } from 'src/app/features/dialogs/models/builder/dialog.builder';
 import { DialogConfiguration } from 'src/app/features/dialogs/models/configuration/dialog-configuration.model';
+import { DyslexicTextComponent } from 'src/app/features/dyslexia/components/dyslexic-text/dyslexic-text.component';
 
 @Component({
 	selector: 'background-dialog',
@@ -18,7 +19,7 @@ import { DialogConfiguration } from 'src/app/features/dialogs/models/configurati
 	standalone: true,
 	imports: [
 		MatCheckbox, MatSlider, MatSliderThumb, ReactiveFormsModule,
-		BaseDialogComponent,
+		BaseDialogComponent, DyslexicTextComponent,
 	],
 })
 export class BackgroundDialogComponent extends DialogComponent {

--- a/src/app/features/dyslexia/components/dyslexia-dialog/dyslexia-dialog.component.html
+++ b/src/app/features/dyslexia/components/dyslexia-dialog/dyslexia-dialog.component.html
@@ -1,7 +1,15 @@
 <base-dialog [configuration]="dialogConfiguration()">
 	<main>
-		<p><dyslexic-text text="Oh you thought you were safe from the text moving, huh?"/></p>
-		<p><dyslexic-text text="This ain't no static website. But I'm happy to have bamboozled you."/></p>
+		<p><dyslexic-text text="
+			Have you recently wondered whether you have dyslexia?
+		"/></p>
+		<p><dyslexic-text text="
+			Every once in a while you look at a page, and you could swear that the words are moving on you.
+			But you blink and its gone. Those slippery words.
+		"/></p>
+		<p><dyslexic-text text="
+			Well, I'm happy to have bamboozled you.
+		"/></p>
 
 		<mat-checkbox class="mat-menu-item" color="primary"
 					  [formControl]="enabledControl"
@@ -12,7 +20,7 @@
 		@if (enabled()) {
 			<p><dyslexic-text text="Yeah make it worse, why not. Might as well, while you're here."/></p>
 		} @else {
-			<p>Why did I even bother adding this feature, huh?</p>
+			<p>Oh you have your own dyslexia? Why didn't you say so earlier?</p>
 		}
 
 		<mat-slider showTickMarks color="primary" [min]="minAmount" [max]="maxAmount" step="1"

--- a/src/app/features/dyslexia/components/dyslexic-text/dyslexic-text.component.ts
+++ b/src/app/features/dyslexia/components/dyslexic-text/dyslexic-text.component.ts
@@ -9,7 +9,8 @@ import { SubSink } from 'subsink';
 
 @Component({
 	selector: 'dyslexic-text',
-	template: '{{ outputText() }}',
+	template: '',
+	host: { '[innerHTML]': 'outputText()' },
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	standalone: true,
 })


### PR DESCRIPTION
Now, admittedly. There are two long term problems with this:

The first one is that dyslexic text is not currently smart enough to realize what is or isn't an html tag. But that's _okay_, because the only html tags I'm currently passing through are `<i>` and `<b>`. And thanks to the internal parsing of word boundaries, any tag less than 4 chars long is safe from dyslexic reordering.

The second long term problem is dom sanitation. We could use `DomSanitizer::bypassSecurityTrustHtml` to require the output to be sanitized, before passing it to `innerHTML`. But I have not added that layer at this time.
