### PR TITLE
Extended Color Themes

### DIFF
--- a/src/app/core/colors/components/theme-picker/theme-picker.component.ts
+++ b/src/app/core/colors/components/theme-picker/theme-picker.component.ts
@@ -23,10 +23,10 @@ export class ThemePickerComponent {
 	public readonly backgroundColor = computed(() => this.theme().colorDefaultBackground);
 	public readonly color = computed(() => this.theme().colorDefaultText);
 	public readonly message = computed(() => {
-		switch (this.theme().themeName) {
-			case 'light-theme':
+		switch (this.theme().prefers) {
+			case 'light':
 				return 'Have a nice day!';
-			case 'dark-theme':
+			case 'dark':
 				return 'Have a nice night!';
 			default:
 				return this.theme().themeName;

--- a/src/app/core/colors/models/color-palettes/color-palette.model.ts
+++ b/src/app/core/colors/models/color-palettes/color-palette.model.ts
@@ -35,6 +35,26 @@ export class ColorPalette extends BaseColorPalette {
 	}
 
 	/**
+	 * Makes a direct copy of the palette.
+	 *
+	 * @return - a new ColorPalette with copied values
+	 */
+	public copy(): ColorPalette {
+		return new ColorPalette(
+			this.lightestColor,
+			this.lighterColor,
+			this.lightColor,
+			this.defaultColor,
+			this.darkColor,
+			this.darkerColor,
+			this.darkestColor,
+			this.paletteName,
+			this.displayName,
+			this.theme,
+		);
+	}
+
+	/**
 	 * Inverse the palette's values, so that the darkest color becomes the lightest and so on.
 	 *
 	 * @param theme - the new ColorTheme to base generated palette variables on.

--- a/src/app/core/colors/models/color-themes/color-theme.model.ts
+++ b/src/app/core/colors/models/color-themes/color-theme.model.ts
@@ -18,6 +18,7 @@ export class ColorTheme extends BaseColorTheme {
 		public readonly disabledTextColor: Color,
 		public readonly lightTextColor: Color,
 
+		public readonly prefers: 'light' | 'dark',
 		public readonly themeName: string,
 		public readonly displayName: string,
 	) {

--- a/src/app/core/colors/models/color-themes/color-themes.constant.ts
+++ b/src/app/core/colors/models/color-themes/color-themes.constant.ts
@@ -9,6 +9,7 @@ export const LightTheme = new ColorTheme(
 	Color.fromString('#616f77'),
 	Color.fromString('#95a2a9'),
 	Color.fromString('white'),
+	'light',
 	'light-theme',
 	'Light',
 );
@@ -21,11 +22,40 @@ export const DarkTheme = new ColorTheme(
 	Color.fromString('rgb(234, 240, 244)'),
 	Color.fromString('rgba(255, 255, 255, 0.7)'),
 	Color.fromString('black'),
+	'dark',
 	'dark-theme',
 	'Dark',
 );
 
+export const PaperTheme = new ColorTheme(
+	Color.fromString('#fffbf7'),
+	Color.fromString('#fff6ec'),
+	Color.fromString('#ffefdd'),
+	Color.fromString('rgba(0, 0, 0, 0.87)'),
+	Color.fromString('#616f77'),
+	Color.fromString('#95a2a9'),
+	Color.fromString('white'),
+	'light',
+	'paper-theme',
+	'Paper',
+);
+
+export const DarkerTheme = new ColorTheme(
+	Color.fromString('black'),
+	Color.fromString('#121212'),
+	Color.fromString('#212121'),
+	Color.fromString('rgb(234, 240, 244)'),
+	Color.fromString('lightgrey'),
+	Color.fromString('rgba(255, 255, 255, 0.7)'),
+	Color.fromString('black'),
+	'dark',
+	'darker-theme',
+	'Darker',
+);
+
 export const ColorThemes = [
 	LightTheme,
+	PaperTheme,
 	DarkTheme,
+	DarkerTheme,
 ] as const;

--- a/src/app/core/colors/services/colors.service.ts
+++ b/src/app/core/colors/services/colors.service.ts
@@ -44,9 +44,9 @@ export class ColorsService {
 		const theme = this.theme();
 		const palette = this.palette();
 
-		return (palette.theme.themeName !== theme.themeName)
+		return (theme.prefers === 'dark')
 			? palette.inverse(theme)
-			: palette;
+			: palette.copy();
 	}
 	// region setters
 
@@ -65,9 +65,9 @@ export class ColorsService {
 
 	private set documentBodyThemeClass(theme: ColorTheme) {
 		ColorThemes.forEach(colorTheme =>
-			this.renderer.removeClass(this.body, colorTheme.themeName));
+			this.renderer.removeClass(this.body, `${ colorTheme.prefers }-theme`));
 
-		this.renderer.addClass(this.body, theme.themeName);
+		this.renderer.addClass(this.body, `${ theme.prefers }-theme`);
 	}
 
 	private set cssThemeVariables(theme: ColorTheme) {

--- a/src/app/core/dialogs/components/base-dialog/base-dialog.component.scss
+++ b/src/app/core/dialogs/components/base-dialog/base-dialog.component.scss
@@ -30,3 +30,11 @@ base-dialog {
 		}
 	}
 }
+
+.light-theme base-dialog {
+	background-color: var(--default-background-color);
+}
+
+.dark-theme base-dialog {
+	background-color: var(--accent-background-color);
+}

--- a/src/app/features/about/models/about-card-data.constant.ts
+++ b/src/app/features/about/models/about-card-data.constant.ts
@@ -9,7 +9,7 @@ export const aboutCardData: readonly AboutCardData[] = [
 		},
 	},
 	{
-		title: 'About',
+		title: 'Author',
 		content: [
 			{
 				title: 'name',

--- a/src/app/features/about/models/braces.constant.ts
+++ b/src/app/features/about/models/braces.constant.ts
@@ -25,7 +25,7 @@ export const bracePairs: readonly BracePair[] = [
 
 export abstract class Braces {
 	public static random$(): Observable<BracePair> {
-		return timer(0, 1000).pipe(map(() => this.random()));
+		return timer(0, 2000).pipe(map(() => this.random()));
 	}
 
 	public static random(): BracePair {

--- a/src/app/features/navigation/components/sidebar-item/sidebar-item.component.scss
+++ b/src/app/features/navigation/components/sidebar-item/sidebar-item.component.scss
@@ -1,19 +1,19 @@
 :host {
 	.sidebar-item {
-		color: inherit;
 		text-decoration: none;
 
 		&.active-route .mat-mdc-card {
-			background-color: var(--default-theme-color);
+			background-color: var(--light-theme-color);
 
 			&:hover {
-				background-color: var(--default-theme-color);
+				background-color: var(--light-theme-color);
 			}
 		}
 
 		.mat-mdc-card {
 			cursor: pointer;
 			background-color: var(--lightest-theme-color);
+			color: var(--dark-text-color);
 
 			&:hover {
 				background-color: var(--lighter-theme-color);

--- a/src/app/features/navigation/components/sidebar/sidebar.component.scss
+++ b/src/app/features/navigation/components/sidebar/sidebar.component.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-flow: column nowrap;
 	background-color: var(--default-background-color);
+	color: var(--default-text-color);
 	height: 100%;
 	overflow: hidden;
 
@@ -9,9 +10,8 @@
 		justify-content: space-between;
 
 		> .title-wrapper {
-			color: var(--default-text-color);
 			line-height: 2.5rem;
-			background-color: var(--hover-background-color);
+			background-color: var(--accent-background-color);
 			border-radius: 0.5rem;
 			padding: 0 0.75rem;
 		}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,9 +4,6 @@
 /* Fonts */
 @use './styles/fonts';
 
-/* Colors */
-@use './styles/variables/colors';
-
 /* Overrides */
 @use './styles/overrides/browser-overrides';
 @use './styles/overrides/material-overrides';

--- a/src/styles/material/mat-card.scss
+++ b/src/styles/material/mat-card.scss
@@ -19,3 +19,13 @@
 		font-variant: small-caps;
 	}
 }
+
+.light-theme .mat-mdc-card {
+	background-color: var(--default-background-color);
+	color: var(--default-text-color);
+}
+
+.dark-theme .mat-mdc-card {
+	background-color: var(--accent-background-color);
+	color: var(--default-text-color);
+}

--- a/src/styles/material/mat-checkbox.scss
+++ b/src/styles/material/mat-checkbox.scss
@@ -1,0 +1,3 @@
+.mat-mdc-checkbox .mdc-label {
+	color: var(--default-text-color);
+}

--- a/src/styles/material/mat-menu.scss
+++ b/src/styles/material/mat-menu.scss
@@ -1,0 +1,15 @@
+.mat-mdc-menu-panel .mat-mdc-menu-item {
+	color: var(--default-text-color);
+
+	.mat-icon {
+		color: var(--default-text-color);
+	}
+}
+
+.light-theme .mat-mdc-menu-panel {
+	background-color: var(--default-background-color);
+}
+
+.dark-theme .mat-mdc-menu-panel {
+	background-color: var(--accent-background-color);
+}

--- a/src/styles/material/mat-slide-toggle.scss
+++ b/src/styles/material/mat-slide-toggle.scss
@@ -1,0 +1,3 @@
+.mat-mdc-slide-toggle .mdc-label {
+	color: var(--default-text-color);
+}

--- a/src/styles/material/mat-toolbar.scss
+++ b/src/styles/material/mat-toolbar.scss
@@ -1,7 +1,14 @@
-body:is(.light-theme, .dark-theme) {
-	--navigation-height: var(--mat-toolbar-standard-height);
+body {
+	&:is(.tablet, .desktop) {
+		--navigation-height: var(--mat-toolbar-standard-height);
+	}
 
-	@media (max-width: 599px) {
+	&.mobile {
 		--navigation-height: var(--mat-toolbar-mobile-height);
 	}
+}
+
+mat-toolbar.mat-toolbar {
+	background-color: var(--default-background-color);
+	color: var(--default-text-color);
 }

--- a/src/styles/overrides/material-overrides.scss
+++ b/src/styles/overrides/material-overrides.scss
@@ -1,5 +1,8 @@
 @use 'src/styles/material/mat-card';
+@use 'src/styles/material/mat-checkbox';
 @use 'src/styles/material/mat-icon';
+@use 'src/styles/material/mat-menu';
+@use 'src/styles/material/mat-slide-toggle';
 @use 'src/styles/material/mat-slider';
 @use 'src/styles/material/mat-toolbar';
 @use 'src/styles/material/mat-tooltip';

--- a/src/styles/variables/colors.scss
+++ b/src/styles/variables/colors.scss
@@ -1,4 +1,4 @@
-.demo-colors {
+@mixin demo-colors {
 	/* Light Theme Default Colors */
 	--info-color: #00b3ee;
 	--success-color: #5cb85c;
@@ -35,8 +35,8 @@
 	--selected-background-color-transparent: rgba(3, 157, 221, 0.15);
 }
 
-:not(.default-transition):not(.custom-transition) {
+@mixin color-transition($duration: 250ms) {
 	transition-property: color, text-shadow, background-color, border-color, box-shadow, fill;
-	transition-duration: 250ms;
+	transition-duration: $duration;
 	transition-timing-function: cubic-bezier(.3642, 0, .6358, 1);
 }


### PR DESCRIPTION
Extended color themes to include variants of `light` and `dark`: `paper` and `darker` 

- Added continued material overrides to display those themes seamlessly
- Because much of the application is rendered in material components, this did actively revert the display to use default text colors everywhere