### PR TITLE
sticky header

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -20,11 +20,12 @@ app-root {
 
 		.mat-sidenav-content {
 			@include fitted;
+			overflow-y: auto;
 		}
 
 		section.app-content {
 			@include fitted;
-			overflow-y: auto;
+			overflow-y: visible;
 
 			.page {
 				flex: 1;

--- a/src/app/features/background/components/background/background.component.scss
+++ b/src/app/features/background/components/background/background.component.scss
@@ -3,7 +3,7 @@
 	background-color: var(--lightest-theme-color);
 	background-image: linear-gradient(to top, var(--default-background-color), transparent);
 	width: 100%;
-	height: 100%;
+	height: calc(100% - var(--navigation-height));
 	z-index: -1;
 
 	> canvas {
@@ -17,7 +17,7 @@
 		flex-flow: row nowrap;
 		font-weight: var(--weight-medium);
 		position: absolute;
-		bottom: var(--navigation-height);
+		bottom: 0;
 		right: 0.5rem;
 
 		.mat-divider {

--- a/src/app/features/markdown/fragment-anchor.component.scss
+++ b/src/app/features/markdown/fragment-anchor.component.scss
@@ -9,7 +9,7 @@
 		height: 100%;
 		padding-right: 0.5rem;
 
-		color: var(--lightest-theme-color);
+		color: var(--light-theme-color);
 		text-decoration: none;
 		@include color-transition(200ms);
 

--- a/src/app/features/navigation/components/header/header.component.scss
+++ b/src/app/features/navigation/components/header/header.component.scss
@@ -1,4 +1,8 @@
 :host {
+	position: sticky;
+	top: 0;
+	z-index: 1;
+
 	> mat-toolbar {
 		justify-content: space-between;
 	}


### PR DESCRIPTION
Fixes a bug with markdown `scrollIntoView` which scrolls the app header out of frame in certain browsers.

The app header is also now `position: sticky`... Which doesn't seem entirely necessary from testing. But I also objectively don't trust leaving it relative with the outer container scrolling.