### PR TITLE
katex markdown html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "marked-base-url": "1.1.6",
         "marked-gfm-heading-id": "4.1.1",
         "marked-highlight": "2.2.1",
+        "marked-katex-extension": "5.1.3",
         "marked-smartypants": "1.1.9",
         "nipplejs": "0.10.2",
         "rxjs": "7.8.1",
@@ -6960,6 +6961,11 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ=="
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -9803,9 +9809,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -15806,6 +15812,31 @@
         "node": ">=10"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.11.tgz",
+      "integrity": "sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "peer": true,
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -16601,6 +16632,18 @@
       "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.1.tgz",
       "integrity": "sha512-SiCIeEiQbs9TxGwle9/OwbOejHCZsohQRaNTY2u8euEXYt2rYUFoiImUirThU3Gd/o6Q1gHGtH9qloHlbJpNIA==",
       "peerDependencies": {
+        "marked": ">=4 <16"
+      }
+    },
+    "node_modules/marked-katex-extension": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/marked-katex-extension/-/marked-katex-extension-5.1.3.tgz",
+      "integrity": "sha512-j4qu6XxFdP5v1VQ1QJ2I3H2DZLd0ak+98L0/IryZ/LHDcKikppHbaydNzVv3EE7t5/Tsrfuywnzlu46lCz0FrQ==",
+      "dependencies": {
+        "@types/katex": "^0.16.7"
+      },
+      "peerDependencies": {
+        "katex": ">=0.16 <0.17",
         "marked": ">=4 <16"
       }
     },
@@ -27178,6 +27221,11 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/katex": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ=="
+    },
     "@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -29257,9 +29305,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -33684,6 +33732,23 @@
         "source-map-support": "^0.5.5"
       }
     },
+    "katex": {
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.11.tgz",
+      "integrity": "sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==",
+      "peer": true,
+      "requires": {
+        "commander": "^8.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+          "peer": true
+        }
+      }
+    },
     "keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -34247,6 +34312,14 @@
       "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.1.tgz",
       "integrity": "sha512-SiCIeEiQbs9TxGwle9/OwbOejHCZsohQRaNTY2u8euEXYt2rYUFoiImUirThU3Gd/o6Q1gHGtH9qloHlbJpNIA==",
       "requires": {}
+    },
+    "marked-katex-extension": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/marked-katex-extension/-/marked-katex-extension-5.1.3.tgz",
+      "integrity": "sha512-j4qu6XxFdP5v1VQ1QJ2I3H2DZLd0ak+98L0/IryZ/LHDcKikppHbaydNzVv3EE7t5/Tsrfuywnzlu46lCz0FrQ==",
+      "requires": {
+        "@types/katex": "^0.16.7"
+      }
     },
     "marked-smartypants": {
       "version": "1.1.9",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "marked-base-url": "1.1.6",
     "marked-gfm-heading-id": "4.1.1",
     "marked-highlight": "2.2.1",
+    "marked-katex-extension": "5.1.3",
     "marked-smartypants": "1.1.9",
     "nipplejs": "0.10.2",
     "rxjs": "7.8.1",

--- a/src/app/features/markdown/markdown.component.scss
+++ b/src/app/features/markdown/markdown.component.scss
@@ -18,4 +18,8 @@ markdown {
 	.hljs-string {
 		color: var(--success-color);
 	}
+
+	.katex-html {
+		display: none;
+	}
 }

--- a/src/app/features/markdown/markdown.component.ts
+++ b/src/app/features/markdown/markdown.component.ts
@@ -8,6 +8,7 @@ import { Marked } from 'marked';
 import { baseUrl } from 'marked-base-url';
 import { getHeadingList, gfmHeadingId, resetHeadings } from 'marked-gfm-heading-id';
 import { markedHighlight } from 'marked-highlight';
+import markedKatex from 'marked-katex-extension';
 import { markedSmartypants } from 'marked-smartypants';
 import { RouterService } from 'src/app/core/browser/services/router.service';
 import { FragmentAnchorComponent } from 'src/app/features/markdown/fragment-anchor.component';
@@ -70,6 +71,9 @@ export class MarkdownComponent implements OnInit, OnDestroy {
 					const language = hljs.getLanguage(_lang) ? _lang : 'plaintext';
 					return hljs.highlight(_code, { language }).value;
 				},
+			}),
+			markedKatex({
+				nonStandard: true,
 			}),
 			markedSmartypants(),
 		);


### PR DESCRIPTION
I will admit, this is slightly ridiculous.

First of all, you want to write `Markdown` instead of directly writing `HTML`.
Fine, sure. That's one layer of abstraction to another language.

But then, now you want to write `TeX` instead of `Markdown`.

So now we're parsing `TeX` inside of parsing `Markdown`, in order to produce `HTML` for the lot.