### PR TITLE
improved static app colors

### DIFF
--- a/src/app/core/colors/models/color-themes/color-theme.model.spec.ts
+++ b/src/app/core/colors/models/color-themes/color-theme.model.spec.ts
@@ -50,22 +50,22 @@ describe('Color Theme', () => {
 	describe('Base Color Theme Values', () => {
 		it('should contain correct colorInfo', () => {
 			const { colorInfo } = LightTheme;
-			expect(colorInfo).toBe('rgb(0, 179, 238)');
+			expect(colorInfo).toBe('rgb(0, 98, 122)');
 		});
 
 		it('should contain correct colorSuccess', () => {
 			const { colorSuccess } = LightTheme;
-			expect(colorSuccess).toBe('rgb(92, 184, 92)');
+			expect(colorSuccess).toBe('rgb(6, 125, 23)');
 		});
 
 		it('should contain correct colorWarning', () => {
 			const { colorWarning } = LightTheme;
-			expect(colorWarning).toBe('rgb(240, 173, 78)');
+			expect(colorWarning).toBe('rgb(196, 114, 51)');
 		});
 
 		it('should contain correct colorDanger', () => {
 			const { colorDanger } = LightTheme;
-			expect(colorDanger).toBe('rgb(217, 83, 79)');
+			expect(colorDanger).toBe('rgb(245, 0, 0)');
 		});
 
 		it('should contain correct colorDefaultBackground', () => {

--- a/src/app/core/colors/models/color-themes/color-theme.model.ts
+++ b/src/app/core/colors/models/color-themes/color-theme.model.ts
@@ -2,17 +2,20 @@ import { BaseColorTheme } from 'src/app/core/colors/models/color-themes/base-col
 import { Color } from 'src/app/core/colors/models/color.model';
 
 export class ColorTheme extends BaseColorTheme {
-	public static readonly infoColor = Color.fromString('#00b3ee');
-	public static readonly successColor = Color.fromString('#5cb85c');
-	// public static readonly successColor = Color.fromString('#6AAB73'); // Intellij Dark Theme String Color
-	// public static readonly successColor = Color.fromString('#0a7248'); // Pantone PMS 18-6032 TSX [Putting Green]
-	public static readonly warningColor = Color.fromString('#f0ad4e');
-	// public static readonly warningColor = Color.fromString('#ff6c2f'); // Pantone 021 U [Orange]
-	// public static readonly warningColor = Color.fromString('#ff6d2b'); // Pantone 15-1360 TN [Shocking Orange]
-	// public static readonly warningColor = Color.fromString('#c7622b'); // Pantone 16-1448 TPX [Burnt Orange]
-	// public static readonly warningColor = Color.fromString('#ffad4a'); // Pantone 14-1050 TPX [Marigold]
-	public static readonly dangerColor = Color.fromString('#d9534f');
-	// public static readonly dangerColor = Color.fromString('#d93744'); // Pantone 17-1663 TCX [Bittersweet]
+
+	// Light Static App Colors
+	public static readonly infoColorLight = Color.fromString('#00627A'); /* IntelliJ light theme method color */
+	public static readonly successColorLight = Color.fromString('#067D17'); /* Intellij light theme string color */
+	public static readonly warningColorLight = Color.fromString('#C47233'); /* Intellij light theme error mark color */
+	public static readonly dangerColorLight = Color.fromString('#F50000'); /* IntelliJ light theme unknown symbol color */
+
+	// Dark Static App Colors
+	public static readonly infoColorDark = Color.fromString('#57AAF7'); /* IntelliJ dark theme method color */
+	public static readonly successColorDark = Color.fromString('#6AAB73'); /* Intellij dark theme string color */
+	public static readonly warningColorDark = Color.fromString('#CF8E6D'); /* Intellij dark theme keyword color */
+	public static readonly dangerColorDark = Color.fromString('#F75464'); /* IntelliJ dark theme bad character color */
+
+	// Static App Colors
 	public static readonly shadowColor = Color.fromString('black');
 
 	public constructor(
@@ -31,10 +34,10 @@ export class ColorTheme extends BaseColorTheme {
 	) {
 		super(
 			/* Static App Colors */
-			ColorTheme.infoColor.toString(),
-			ColorTheme.successColor.toString(),
-			ColorTheme.warningColor.toString(),
-			ColorTheme.dangerColor.toString(),
+			(prefers === 'light') ? ColorTheme.infoColorLight.toString() : ColorTheme.infoColorDark.toString(),
+			(prefers === 'light') ? ColorTheme.successColorLight.toString() : ColorTheme.successColorDark.toString(),
+			(prefers === 'light') ? ColorTheme.warningColorLight.toString() : ColorTheme.warningColorDark.toString(),
+			(prefers === 'light') ? ColorTheme.dangerColorLight.toString() : ColorTheme.dangerColorDark.toString(),
 
 			/* Background Colors */
 			defaultBackgroundColor.toString(),

--- a/src/app/features/markdown/markdown.component.scss
+++ b/src/app/features/markdown/markdown.component.scss
@@ -5,13 +5,11 @@ markdown {
 	@include content-layout;
 
 	.hljs-keyword {
-		color: var(--danger-color);
-		font-weight: var(--weight-normal);
-		font-style: italic;
+		color: var(--warning-color);
 	}
 
 	.hljs-title {
-		color: var(--warning-color);
+		color: var(--info-color);
 		font-style: italic;
 	}
 

--- a/src/styles/mixins/colors.scss
+++ b/src/styles/mixins/colors.scss
@@ -1,9 +1,9 @@
 @mixin demo-colors {
 	/* Light Theme Default Colors */
-	--info-color: #00b3ee;
-	--success-color: #5cb85c;
-	--warning-color: #f0ad4e;
-	--danger-color: #d9534f;
+	--info-color: #00627A;
+	--success-color: #067D17;
+	--warning-color: #C47233;
+	--danger-color: #F50000;
 
 	--default-background-color: white;
 	--accent-background-color: whitesmoke;

--- a/src/styles/overrides/browser-overrides.scss
+++ b/src/styles/overrides/browser-overrides.scss
@@ -72,7 +72,7 @@ code {
 	display: inline-block;
 	font-family: var(--monospace-font);
 	font-weight: var(--weight-medium);
-	background-color: var(--accent-background-color);
+	background-color: rgba(from var(--accent-background-color) r g b / calc(alpha * 2 / 3));
 	border-radius: 4px;
 	padding: 0 0.5rem;
 }


### PR DESCRIPTION
`Info`, `Success`, `Warning`, & `Danger` are some residual scum that have been haunting color systems since time immemorial. And they have never really come into their own in this system either. Not that this really changes that, but at least there is a marginally more thought put into them.